### PR TITLE
Remove empty RPM before install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,11 @@ class jdk_oracle (
       file { $tmp_dir: ensure => 'directory', }
     }
   } else {
+    exec { 'remove_empty_jdk_installer':
+      cwd     => $tmp_dir,
+      command => "rm -f ${installer_filename}",
+      unless  => "test -s ${installer_filename}",
+    } ->
     exec { 'get_jdk_installer':
       cwd     => $tmp_dir,
       creates => "${tmp_dir}/${installer_filename}",


### PR DESCRIPTION
  - On occasion, wget fails to download the rpm and leaves a zero
    byte rpm. That file prevents future puppet runs. These changes
    ensure that zero byte file's removed to try and download the rpm
    again.